### PR TITLE
Use mv instead of cp&rm; Don't overwrite existing saves.

### DIFF
--- a/lgso.sh
+++ b/lgso.sh
@@ -104,17 +104,14 @@ read_flags() {
 }
 
 move_save() {
-   if [ ! -d "$NEW_DIR" ]; then
-      if [[ $OUTPUT -eq 1 ]]; then
-         echo "Source path: $OLD_DIR"
-         echo "Destination path: $NEW_DIR"
-      fi
-
-      if [[ $OUTPUT -eq 1 ]]; then
-         echo "Creating $NEW_DIR"
-      fi
-
-      mkdir $NEW_DIR
+   if [ -d "$NEW_DIR" ]; then
+      echo "Error: Directory $NEW_DIR already exists. If you want to overwrite saved games in this directory, please remove it manually." >/dev/stderr
+      return 1
+   elif
+   
+   if [[ $OUTPUT -eq 1 ]]; then
+      echo "Source path: $OLD_DIR"
+      echo "Destination path: $NEW_DIR"
    fi
 
    if [[ $OUTPUT -eq 1 ]]; then


### PR DESCRIPTION
Hi there!

Here are two, in my option useful changes: First, should any game somehow mistreat symlink and re-create save directory, your script will move newly created stuff over old saves, most likely creating something unusable. With check [ -d "$NEW_DIR" ] in 5fe37bc this will not happen.

And second, d1fa097, using mv is faster than copying and removing, as average user has his $HOME only on one partition. And safer... Your original script may fail on cp and then happily rm old saves...
